### PR TITLE
Fixed schema for webhooks, don't expect type from orgs

### DIFF
--- a/src/app/api/webhooks/github/schemas.ts
+++ b/src/app/api/webhooks/github/schemas.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 export const githubUserSchema = z.object({
   login: z.string(),
   id: z.number(),
-  type: z.string(),
 });
 
 export const githubRepositorySchema = z.object({
@@ -44,7 +43,9 @@ export const githubWebhookPayloadSchema = z.discriminatedUnion("event_type", [
   z.object({
     event_type: z.literal("issue_comment"),
     ...githubWebhookBaseSchema.shape,
-    sender: githubUserSchema,
+    sender: githubUserSchema.extend({
+      type: z.string(),
+    }),
   }),
   z.object({
     event_type: z.literal("release"),


### PR DESCRIPTION
## Description

Don't expect `type` field from org field in webhook events.