### PR TITLE
get user instead of session from supabase warning

### DIFF
--- a/src/app/layout/profile-dropdown/actions.ts
+++ b/src/app/layout/profile-dropdown/actions.ts
@@ -6,18 +6,18 @@ import type { Tables } from "@/types/supabase";
 export async function getCurrentUser(): Promise<Tables<"users"> | null> {
   const supabase = createClient(cookies());
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  if (!session?.user) return null;
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
 
-  const userId = session.user.id;
-  const { data: user } = await supabase
+  const userId = user.id;
+  const { data: userData } = await supabase
     .from("users")
     .select("*")
     .eq("id", userId)
     .single();
 
-  return user ?? null;
+  return userData ?? null;
 }
 
 getCurrentUser.key = "src/app/layout/profile-dropdown/actions/getCurrentUser";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,13 +8,13 @@ import Feed from "./page/feed";
 export default async function Home() {
   const supabase = createClient(cookies());
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
+    data: { user },
+  } = await supabase.auth.getUser();
 
   return (
     <div className="px-2 flex flex-col gap-4">
       <ClaimRepoButton />
-      <Feed session={session} />
+      <Feed user={user} />
     </div>
   );
 }

--- a/src/app/page/feed.tsx
+++ b/src/app/page/feed.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { Session } from "@supabase/supabase-js";
-
+import { User } from "@supabase/supabase-js";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
 import FeedPrivate from "./feed/feed-private";
 import FeedPublic from "./feed/feed-public";
 
-export default function Feed({ session }: { session: Session | null }) {
-  if (!session) {
+export default function Feed({ user }: { user: User | null }) {
+  if (!user) {
     return <FeedPublic />;
   }
 

--- a/src/app/page/feed/actions.ts
+++ b/src/app/page/feed/actions.ts
@@ -18,15 +18,15 @@ export async function fetchFeed({
 }) {
   const supabase = createClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  if (!session?.user) throw new NotAuthenticatedError();
+  if (!user) throw new NotAuthenticatedError();
 
   const { data } = await supabase
     .from("user_timeline")
     .select("*, repositories ( org, repo )")
-    .eq("user_id", session.user.id)
+    .eq("user_id", user.id)
     .order("updated_at", { ascending: false })
     .order("created_at", { ascending: false })
     .range(offset, offset + limit - 1)

--- a/src/components/[org]/[repo]/repo-profile-card/actions.ts
+++ b/src/components/[org]/[repo]/repo-profile-card/actions.ts
@@ -12,12 +12,12 @@ export class NotAuthenticatedError extends Error {
 export async function createSubscription(org: string, repo: string) {
   const supabase = createClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  if (!session?.user) throw new NotAuthenticatedError();
+  if (!user) throw new NotAuthenticatedError();
 
-  const userId = session.user.id;
+  const userId = user.id;
 
   // Get repo id from org/repo
   const { data: repoData } = await supabase
@@ -71,11 +71,11 @@ export async function createSubscription(org: string, repo: string) {
 export async function removeSubscription(org: string, repo: string) {
   const supabase = createClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  if (!session?.user) throw new NotAuthenticatedError();
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new NotAuthenticatedError();
 
-  const userId = session.user.id;
+  const userId = user.id;
 
   // Get repo id from org/repo
   const { data: repoData } = await supabase
@@ -98,12 +98,12 @@ export async function removeSubscription(org: string, repo: string) {
 export async function isSubscribed(org: string, repo: string) {
   const supabase = createClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  if (!session?.user) {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
     return { subscribed: false };
   }
-  const userId = session.user.id;
+  const userId = user.id;
 
   // Get repo id from org/repo
   const { data: repoData } = await supabase

--- a/src/components/shared/activity-card/actions.ts
+++ b/src/components/shared/activity-card/actions.ts
@@ -9,12 +9,12 @@ export class NotAuthenticatedError extends Error {
 export async function isLiked(dedupe_hash: string) {
   const supabase = createClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  if (!session?.user) {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
     return { liked: false };
   }
-  const userId = session.user.id;
+  const userId = user.id;
 
   const { data: likeData } = await supabase
     .from("timeline_likes")
@@ -31,10 +31,10 @@ isLiked.key = "src/components/shared/activity-card/actions/isLiked";
 export async function createLike(dedupe_hash: string) {
   const supabase = createClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  if (!session?.user) throw new NotAuthenticatedError();
-  const userId = session.user.id;
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new NotAuthenticatedError();
+  const userId = user.id;
 
   await supabase
     .from("timeline_likes")
@@ -45,10 +45,10 @@ export async function createLike(dedupe_hash: string) {
 export async function deleteLike(dedupe_hash: string) {
   const supabase = createClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  if (!session?.user) throw new NotAuthenticatedError();
-  const userId = session.user.id;
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new NotAuthenticatedError();
+  const userId = user.id;
 
   await supabase
     .from("timeline_likes")

--- a/src/components/shared/claim-repo-button/actions.ts
+++ b/src/components/shared/claim-repo-button/actions.ts
@@ -4,12 +4,12 @@ import { createClient } from "@/utils/supabase/server";
 export async function fetchRepoCount() {
   const supabase = createClient(cookies());
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  if (!session?.user) return 0;
+  if (!user) return 0;
 
-  const userId = session.user.id;
+  const userId = user.id;
 
   const { count } = await supabase
     .from("repositories_users")


### PR DESCRIPTION
## Description

> Using the user object as returned from supabase.auth.getSession() or from some supabase.auth.onAuthStateChange() events could be insecure! This value comes directly from the storage medium (usually cookies on the server) and may not be authentic. Use supabase.auth.getUser() instead which authenticates the data by contacting the Supabase Auth server.

Fixes this ^ 
