### PR TITLE
Add search box to feed interface

### DIFF
--- a/src/app/page/feed.tsx
+++ b/src/app/page/feed.tsx
@@ -1,27 +1,57 @@
 "use client";
 
+import React, { useState } from "react";
 import { User } from "@supabase/supabase-js";
+import { Search } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Input } from "@/components/ui/input";
 
 import FeedPrivate from "./feed/feed-private";
 import FeedPublic from "./feed/feed-public";
 
 export default function Feed({ user }: { user: User | null }) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [activeQuery, setActiveQuery] = useState("");
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setActiveQuery(searchQuery);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleSearch(e);
+    }
+  };
+
   if (!user) {
-    return <FeedPublic />;
+    return <FeedPublic searchQuery={activeQuery} />;
   }
 
   return (
     <Tabs defaultValue="general" className="w-full">
-      <TabsList>
-        <TabsTrigger value="general">General</TabsTrigger>
-        <TabsTrigger value="following">Following</TabsTrigger>
-      </TabsList>
+      <div className="flex justify-between items-center mb-4">
+        <TabsList>
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="following">Following</TabsTrigger>
+        </TabsList>
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            type="text"
+            placeholder="Search activities..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="pl-10 w-64"
+          />
+        </div>
+      </div>
       <TabsContent value="general">
-        <FeedPublic />
+        <FeedPublic searchQuery={activeQuery} />
       </TabsContent>
       <TabsContent value="following">
-        <FeedPrivate />
+        <FeedPrivate searchQuery={activeQuery} />
       </TabsContent>
     </Tabs>
   );

--- a/src/app/page/feed/feed-private.tsx
+++ b/src/app/page/feed/feed-private.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 
 const LIMIT = 20;
 
-export default function FeedPrivate() {
+export default function FeedPrivate({ searchQuery }: { searchQuery?: string }) {
   const {
     data,
     fetchNextPage,
@@ -23,8 +23,12 @@ export default function FeedPrivate() {
     error,
     refetch,
   } = useInfiniteQuery({
-    queryKey: [fetchFeed.key],
-    queryFn: ({ pageParam }) => fetchFeed({ limit: LIMIT, offset: pageParam }),
+    queryKey: [fetchFeed.key, searchQuery],
+    queryFn: ({ pageParam }) => fetchFeed({ 
+      limit: LIMIT, 
+      offset: pageParam,
+      query: searchQuery 
+    }),
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.hasMore) {
         return allPages.reduce((acc, page) => acc + page.items.length, 0);

--- a/src/app/page/feed/feed-public.tsx
+++ b/src/app/page/feed/feed-public.tsx
@@ -12,7 +12,7 @@ import { fetchPublicFeed } from "./actions";
 
 const LIMIT = 20;
 
-export default function FeedPublic() {
+export default function FeedPublic({ searchQuery }: { searchQuery?: string }) {
   const {
     data,
     fetchNextPage,
@@ -23,9 +23,13 @@ export default function FeedPublic() {
     error,
     refetch,
   } = useInfiniteQuery({
-    queryKey: [fetchPublicFeed.key],
+    queryKey: [fetchPublicFeed.key, searchQuery],
     queryFn: ({ pageParam }) =>
-      fetchPublicFeed({ limit: LIMIT, offset: pageParam }),
+      fetchPublicFeed({ 
+        limit: LIMIT, 
+        offset: pageParam,
+        query: searchQuery 
+      }),
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.hasMore) {
         return allPages.reduce((acc, page) => acc + page.items.length, 0);


### PR DESCRIPTION
## Description

This PR introduces a search box to the General and Following activity feeds, enabling users to filter activities based on a search query.

-   **Search Capability:** A search input is now available next to the feed tabs.
-   **Query Trigger:** Users can type a query and press `Enter` to filter the displayed activities.
-   **Unified Search:** The search functionality applies consistently across both "General" and "Following" feeds.
-   **Backend Integration:** Leverages existing full-text search capabilities within the `fetchFeed` and `fetchPublicFeed` actions.
-   **UI Layout:** The layout uses `justify-between` to ensure proper spacing between the tabs and the new search input.

## How to test

1.  Navigate to the main feed page (`/`).
2.  Observe the new search box positioned next to the "General" and "Following" tabs.
3.  Type a search query (e.g., "post", "new feature") into the search box.
4.  Press `Enter`.
5.  Verify that the feed content updates to show activities matching the search query.
6.  Clear the search box and press `Enter` again to see all activities.
7.  Switch between "General" and "Following" tabs while a search query is active to ensure the search persists correctly.