### PR TITLE
Remove Claude skill and update llms.txt base URL to beta.nomit.dev

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,0 @@
-{
-  "name": "nom",
-  "version": "1.0.0",
-  "description": "Query the Nom GitHub activity feed from Claude Code",
-  "author": { "name": "nom" },
-  "skills": "./skills/"
-}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -10,7 +10,7 @@
 
 ## Public API
 
-Base URL: https://nomit.dev
+Base URL: https://beta.nomit.dev
 
 ### GET /api/feed
 
@@ -82,7 +82,7 @@ Event types: `pull_request`, `issue`, `release`, `push`
 
 ## Key Pages
 
-- https://nomit.dev — Home / global public feed
-- https://nomit.dev/{org}/{repo} — Repository-specific feed (e.g. https://nomit.dev/vercel/next.js)
-- https://nomit.dev/api/feed — Global feed API
-- https://nomit.dev/api/feed/{org}/{repo} — Repo feed API
+- https://beta.nomit.dev — Home / global public feed
+- https://beta.nomit.dev/{org}/{repo} — Repository-specific feed (e.g. https://beta.nomit.dev/vercel/next.js)
+- https://beta.nomit.dev/api/feed — Global feed API
+- https://beta.nomit.dev/api/feed/{org}/{repo} — Repo feed API


### PR DESCRIPTION
## Summary

- Remove `.claude-plugin/` — the `llms.txt` is sufficient for LLM/agent discoverability without needing a dedicated Claude skill
- Update all API base URLs in `public/llms.txt` from `nomit.dev` → `beta.nomit.dev`

## Test plan

- [ ] Verify `https://beta.nomit.dev/api/feed` is reachable and returns expected JSON
- [ ] Confirm `.claude-plugin/` directory is gone from the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)