### PR TITLE
Repository ownership visibility

### DIFF
--- a/src/app/[org]/[repo]/page/actions.ts
+++ b/src/app/[org]/[repo]/page/actions.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { escapeForIlike } from "@/lib/repo-utils";
+import { canUserAccessRepo } from "@/lib/repository-visibility";
 import { createClient } from "@/utils/supabase/server";
 
 const metadataSchema = z.object({
@@ -19,39 +20,48 @@ const metadataSchema = z.object({
 
 export async function fetchRepoProfile(org: string, repo: string) {
   const supabase = await createClient();
-  const { data } = await supabase
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data: repoData } = await supabase
     .from("repositories")
     .select("metadata, org, repo, id, is_private")
     .ilike("org", escapeForIlike(org))
     .ilike("repo", escapeForIlike(repo))
     .single();
 
-  const { count: subscriptionCount } = await supabase
-    .from("subscriptions")
-    .select("*", { count: "exact", head: true })
-    .eq("repo_id", data?.id || "");
-
-  if (!data) {
+  if (!repoData) {
     return null;
   }
 
-  const parseResult = metadataSchema.safeParse(data.metadata);
+  const hasAccess = await canUserAccessRepo(supabase, repoData, user?.id);
+  if (!hasAccess) {
+    return null;
+  }
+
+  const { count: subscriptionCount } = await supabase
+    .from("subscriptions")
+    .select("*", { count: "exact", head: true })
+    .eq("repo_id", repoData.id);
+
+  const parseResult = metadataSchema.safeParse(repoData.metadata);
   if (!parseResult.success) {
     return null;
   }
   const meta = parseResult.data;
 
   return {
-    org: data.org,
-    repo: data.repo,
+    org: repoData.org,
+    repo: repoData.repo,
     createdAt: new Date(meta.created_at),
     description: meta.description,
     websiteUrl: meta.homepage_url,
     avatarUrl: meta.avatar_url,
     topLanguages: meta.languages,
     license: meta.license,
-    id: data.id,
+    id: repoData.id,
     subscriptionCount: subscriptionCount || 0,
-    isPrivate: data.is_private,
+    isPrivate: repoData.is_private,
   };
 }

--- a/src/app/api/feed/rss/route.ts
+++ b/src/app/api/feed/rss/route.ts
@@ -3,6 +3,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { normalizeTimelineItem } from "@/app/api/feed/normalize";
 import { toErrorXml, toRssXml } from "@/app/api/feed/to-rss";
 import { BASE_URL } from "@/lib/constants";
+import {
+  fetchOwnedRepoIds,
+  toPostgrestInList,
+} from "@/lib/repository-visibility";
 import { createClient } from "@/utils/supabase/server";
 
 export async function GET(request: NextRequest) {
@@ -11,10 +15,24 @@ export async function GET(request: NextRequest) {
   const offset = parseInt(searchParams.get("offset") ?? "0", 10);
 
   const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const ownedRepoIds = await fetchOwnedRepoIds(supabase, user?.id);
 
-  const { data, error } = await supabase
+  let queryBuilder = supabase
     .from("public_timeline")
-    .select("*, repositories!inner ( org, repo )")
+    .select("*, repositories!inner ( org, repo, is_private )");
+
+  if (ownedRepoIds.length > 0) {
+    queryBuilder = queryBuilder.or(
+      `repositories.is_private.eq.false,repo_id.in.(${toPostgrestInList(ownedRepoIds)})`
+    );
+  } else {
+    queryBuilder = queryBuilder.eq("repositories.is_private", false);
+  }
+
+  const { data, error } = await queryBuilder
     .order("updated_at", { ascending: false })
     .order("created_at", { ascending: false })
     .range(offset, offset + limit - 1);
@@ -38,10 +56,15 @@ export async function GET(request: NextRequest) {
     feedUrl,
   });
 
+  const cacheControl =
+    user && ownedRepoIds.length > 0
+      ? "private, no-store"
+      : "public, max-age=60, s-maxage=60";
+
   return new NextResponse(xml, {
     headers: {
       "Content-Type": "application/rss+xml; charset=utf-8",
-      "Cache-Control": "public, max-age=60, s-maxage=60",
+      "Cache-Control": cacheControl,
     },
   });
 }

--- a/src/app/page/feed/actions.ts
+++ b/src/app/page/feed/actions.ts
@@ -1,5 +1,9 @@
 import { Tables } from "@/types/supabase";
 import { createClient } from "@/utils/supabase/client";
+import {
+  fetchOwnedRepoIds,
+  toPostgrestInList,
+} from "@/lib/repository-visibility";
 
 export type FeedItem = Tables<"user_timeline"> & {
   repositories: {
@@ -209,13 +213,22 @@ export async function fetchPublicFeed({
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  const ownedRepoIds = await fetchOwnedRepoIds(supabase, user?.id);
 
   // Parse the search filters
   const filters = parseSearchFilters(query);
 
   let queryBuilder = supabase
     .from("public_timeline")
-    .select("*, repositories!inner ( org, repo )");
+    .select("*, repositories!inner ( org, repo, is_private )");
+
+  if (ownedRepoIds.length > 0) {
+    queryBuilder = queryBuilder.or(
+      `repositories.is_private.eq.false,repo_id.in.(${toPostgrestInList(ownedRepoIds)})`
+    );
+  } else {
+    queryBuilder = queryBuilder.eq("repositories.is_private", false);
+  }
 
   if (filters.org || filters.owner) {
     queryBuilder = queryBuilder.eq(

--- a/src/app/page/feed/server.ts
+++ b/src/app/page/feed/server.ts
@@ -1,4 +1,8 @@
 import { createClient } from "@/utils/supabase/server";
+import {
+  fetchOwnedRepoIds,
+  toPostgrestInList,
+} from "@/lib/repository-visibility";
 
 import type { PublicFeedItemWithLikes } from "./actions";
 
@@ -56,12 +60,21 @@ export async function fetchPublicFeedServer({
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  const ownedRepoIds = await fetchOwnedRepoIds(supabase, user?.id);
 
   const filters = parseSearchFilters(query);
 
   let queryBuilder = supabase
     .from("public_timeline")
-    .select("*, repositories!inner ( org, repo )");
+    .select("*, repositories!inner ( org, repo, is_private )");
+
+  if (ownedRepoIds.length > 0) {
+    queryBuilder = queryBuilder.or(
+      `repositories.is_private.eq.false,repo_id.in.(${toPostgrestInList(ownedRepoIds)})`
+    );
+  } else {
+    queryBuilder = queryBuilder.eq("repositories.is_private", false);
+  }
 
   if (filters.org || filters.owner) {
     queryBuilder = queryBuilder.eq(

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,7 +8,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const { data: repos } = await supabase
     .from("repositories")
-    .select("org, repo, created_at");
+    .select("org, repo, created_at")
+    .eq("is_private", false);
 
   const repoUrls: MetadataRoute.Sitemap = (repos || []).map((repo) => ({
     url: `${BASE_URL}/${repo.org}/${repo.repo}`,

--- a/src/lib/repository-visibility.ts
+++ b/src/lib/repository-visibility.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database, Tables } from "@/types/supabase";
+
+type RepoVisibilityRecord = Pick<Tables<"repositories">, "id" | "is_private">;
+
+export async function canUserAccessRepo(
+  supabase: SupabaseClient<Database>,
+  repo: RepoVisibilityRecord,
+  userId?: string
+) {
+  if (!repo.is_private) {
+    return true;
+  }
+
+  if (!userId) {
+    return false;
+  }
+
+  const { data: membership } = await supabase
+    .from("repositories_users")
+    .select("id")
+    .eq("repo_id", repo.id)
+    .eq("user_id", userId)
+    .maybeSingle()
+    .throwOnError();
+
+  return Boolean(membership);
+}
+
+export async function fetchOwnedRepoIds(
+  supabase: SupabaseClient<Database>,
+  userId?: string
+) {
+  if (!userId) {
+    return [];
+  }
+
+  const { data } = await supabase
+    .from("repositories_users")
+    .select("repo_id")
+    .eq("user_id", userId)
+    .throwOnError();
+
+  return data.map(({ repo_id }) => repo_id);
+}
+
+export function toPostgrestInList(values: string[]) {
+  return values.map((value) => `"${value}"`).join(",");
+}


### PR DESCRIPTION
## Description

This PR implements robust access control for private repositories, ensuring they are only visible and accessible to their owners.

Previously, private repositories could be viewed or accessed indirectly through various public feeds, API endpoints, or by non-owners. This change centralizes visibility checks and applies them across all user-facing read paths.

**Key changes include:**

-   **Centralized Visibility Logic:** A new `repository-visibility.ts` helper provides functions to determine if a user can access a given repository based on its public status or ownership via the `repositories_users` table.
-   **Enforced Access on Repo Pages & Status:** Direct access to `/[org]/[repo]` and `/[org]/[repo]/status/[status]` pages now requires ownership for private repos.
-   **Subscription Bypass Prevention:** Non-owners can no longer subscribe to private repositories to indirectly view activity.
-   **Global Feed Filtering:** All public feeds (homepage, API, RSS) now only display public repositories, plus any private repositories owned by the currently authenticated user.
-   **Repo-Specific API & RSS Access:** Dedicated API and RSS routes for specific repositories (`/api/feed/[org]/[repo]`) now enforce ownership for private repos, returning a 404 for unauthorized access.
-   **Sitemap Exclusion:** Private repositories are excluded from the sitemap.
-   **Cache-Safety for RSS:** Global and repo-specific RSS feeds now use appropriate `Cache-Control` headers (`private, no-store`) when user-owned private repos might be included, preventing caching of personalized content.

## How to test

1.  **Create a private repository:**
    *   Log in as `UserA`.
    *   Create a new private repository (e.g., `UserA/private-repo`).
2.  **Verify owner access:**
    *   As `UserA`, navigate to `UserA/private-repo`. Verify full access to the repo page, feed, and status updates.
    *   Check the global feed while logged in as `UserA`; `UserA/private-repo` should appear.
    *   Verify `UserA` can subscribe/unsubscribe to `UserA/private-repo`.
3.  **Verify non-owner restriction:**
    *   Log out or log in as `UserB` (who is not an owner of `UserA/private-repo`).
    *   Attempt to navigate to `UserA/private-repo`. Verify a 404 page is displayed.
    *   Check the global feed while logged out or as `UserB`; `UserA/private-repo` should **not** appear.
    *   Attempt to subscribe to `UserA/private-repo` as `UserB`. Verify this action is prevented.
    *   Access the API endpoints for `UserA/private-repo` (e.g., `/api/feed/UserA/private-repo`). Verify a 404 or unauthorized response.
4.  **Verify public repository behavior:**
    *   Create a public repository (e.g., `UserA/public-repo`).
    *   Verify `UserA/public-repo` is accessible to both `UserA` and `UserB` (and logged-out users).
    *   Verify `UserA/public-repo` appears in global feeds for all users.

---
<p><a href="https://cursor.com/agents/bc-c47072b3-353f-49e4-9bd4-976b58d8f956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c47072b3-353f-49e4-9bd4-976b58d8f956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

